### PR TITLE
update nova-translations-loader to new outl1ne namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "laravel/nova": "~4.0",
         "illuminate/support": "^9.0",
-        "optimistdigital/nova-translations-loader": "^5.0"
+        "outl1ne/nova-translations-loader": "^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Update nova-translations-loader composer require to it's new outl1ne/nova-translations-loader namespace.
This fixes the following notice when running composer commands:

```
Warning: Ambiguous class resolution, "Outl1ne\NovaTranslationsLoader\LoadsNovaTranslations" was found 2x: 
in "/development/projectroot/vendor/optimistdigital/nova-translations-loader/src/LoadsNovaTranslations.php"
and "/development/projectroot/vendor/outl1ne/nova-translations-loader/src/LoadsNovaTranslations.php", the first will be used.
```
This happened for me when nova-string-generator-field was required by a composer package in my project. In my other packages references to Outl1ne packages (previously Optimistdigital) were already updated.